### PR TITLE
include md5sum from stream info

### DIFF
--- a/flacParser.js
+++ b/flacParser.js
@@ -11,7 +11,7 @@ module.exports = FlacParser;
 inherits(FlacParser, Tokenizr);
 
 function FlacParser(){
-    if ( !(this instanceof FlacParser) ) 
+    if ( !(this instanceof FlacParser) )
         return new FlacParser();
 
     Tokenizr.call(this, { objectMode: true })
@@ -92,12 +92,13 @@ FlacParser.prototype.parseFlacProps = function(buf, tokens){
         sampleRate: binary.readUInt24BE(buf, 10) >> 4,
         channels: ((buf[12] >> 1) & 0x7) + 1,
         bitsPerSample: ((buf.readUInt16BE(12) >> 4 ) & 0xF) + 1, //first 4 bits of byte 13
-        samplesInStream: buf.readUInt32BE(14) //need to also add last 4 bytes of 13
+        samplesInStream: buf.readUInt32BE(14), //need to also add last 4 bytes of 13
+        md5sum: buf.slice(18, 34).toString('hex')
     }
 
     tokens.properties.duration =  (tokens.properties.samplesInStream / tokens.properties.sampleRate )
 
-    if ( ( buf[13] & 0xF ) !== 0 ) 
+    if ( ( buf[13] & 0xF ) !== 0 )
         debug('samplesInStream number is larger than 32bits, i\'m to lazy to do that math')
 }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -20,11 +20,12 @@ describe('when parsing an Ogg Stream', function(){
             .on('data', function(t){
                 tags[t.type] = t.value;
             })
-            .on('end', function(){
+            .on('finish', function(){
 
                 tags.should.have.property('duration' ).that.is.closeTo(10, 0.1)
                 tags.should.have.property('minBlockSize' ).that.equals(4608)
                 tags.should.have.property('maxBlockSize' ).that.equals(4608)
+                tags.should.have.property('md5sum' ).that.equals('e319cb440fc918fd04a1b2f406fbbc3a')
 
                 tags.should.have.property('minFrameSize' ).that.equals(11)
                 tags.should.have.property('maxFrameSize' ).that.equals(11)


### PR DESCRIPTION
I'm trying to do some simple deduping by keying metadata off the md5sum of the audio stream, and to do that I needed to extract the encoded md5sum. The value included in the test was extracted using `metaflac`.
